### PR TITLE
build: set psycopg2 version to ~2.9.0 and bump django to allow 5.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ authors = [{ name = "william chu", email = "william.chu@uptickhq.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "django>=3.2,<5.1.0",
+    "django>=3.2,<5.2.0",
     "psycopg2~=2.9.0",
     "sqlparse>=0.5.3",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,13 +1,13 @@
 [project]
 name = "django-pev"
-version = "0.3.0"
+version = "0.3.1"
 description = "Context manager to upload explain plans to https://explain.dalibo.com/"
 authors = [{ name = "william chu", email = "william.chu@uptickhq.com" }]
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
     "django>=3.2,<5.1.0",
-    "psycopg2>=2.9.10",
+    "psycopg2~=2.9.0",
     "sqlparse>=0.5.3",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -38,7 +38,7 @@ wheels = [
 
 [[package]]
 name = "django-pev"
-version = "0.3.0"
+version = "0.3.1"
 source = { editable = "." }
 dependencies = [
     { name = "django" },
@@ -57,7 +57,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "django", specifier = ">=3.2,<5.1.0" },
-    { name = "psycopg2", specifier = ">=2.9.10" },
+    { name = "psycopg2", specifier = "~=2.9.0" },
     { name = "sqlparse", specifier = ">=0.5.3" },
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -56,7 +56,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "django", specifier = ">=3.2,<5.1.0" },
+    { name = "django", specifier = ">=3.2,<5.2.0" },
     { name = "psycopg2", specifier = "~=2.9.0" },
     { name = "sqlparse", specifier = ">=0.5.3" },
 ]


### PR DESCRIPTION
When adding django 5.0.0 support, I got a poetry error locally telling me I needed to bump my psycopg2 version.

I bumped to psycopg2@2.9.10, but upon testing this more thoroughly it has brought up a fair amount of issues.

UV seems to be happy with me setting the dependency to be `~2.9.0`