### PR TITLE
PLT-1209 security(gha): Pin all github actions to a fixed sha via ratchet

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,10 +2,10 @@ name: CI
 on:
   push:
     branches:
-    - release/*
-    - develop
-    - master
-    - main
+      - release/*
+      - develop
+      - master
+      - main
   pull_request: {}
 
 permissions:
@@ -18,7 +18,7 @@ permissions:
 
 jobs:
   ci:
-    uses: uptick/actions/.github/workflows/ci.yaml@main
+    uses: uptick/actions/.github/workflows/ci.yaml@main # ratchet:exclude
     secrets: inherit
     with:
       aws: true

--- a/.github/workflows/release_please.yaml
+++ b/.github/workflows/release_please.yaml
@@ -2,7 +2,7 @@ name: Release Please
 on:
   push:
     branches:
-    - main
+      - main
 
 permissions:
   actions: read # Read the metrics
@@ -18,10 +18,10 @@ jobs:
   release_please:
     runs-on: ubuntu-latest
     steps:
-    - uses: googleapis/release-please-action@v4
-      id: release
-      # Configured via: release-please-config.json and will update the manifest: .release-please-manifest.json
-      with: {}
+      - uses: googleapis/release-please-action@16a9c90856f42705d54a6fda1823352bdc62cf38 # ratchet:googleapis/release-please-action@v4
+        id: release
+        # Configured via: release-please-config.json and will update the manifest: .release-please-manifest.json
+        with: {}
     outputs:
       # Root level release_created
       release_created: ${{ steps.release.outputs.release_created }}
@@ -37,11 +37,11 @@ jobs:
     if: ${{ needs.release_please.outputs.release_created }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # ratchet:actions/checkout@v4
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@d0cc045d04ccac9d8b7881df0226f9e82c39688e # ratchet:astral-sh/setup-uv@v6
       - name: Build and Publish
-        run: |
+        run: |-
           uv sync --frozen
           uv build
           uv publish


### PR DESCRIPTION
Github actions are pinned to a specific sha as part of our supply chain strategy. Merge the renovate PR to auto update the github shas. Actions without a pinned sha will no longer be allowed to run.